### PR TITLE
Fix np.random.seed

### DIFF
--- a/test/aqua/operators/test_gradients.py
+++ b/test/aqua/operators/test_gradients.py
@@ -612,7 +612,7 @@ class TestGradients(QiskitAquaTestCase):
 
         shots = 8000
         if method == 'fin_diff':
-            np.random.seed = 8
+            np.random.seed(8)
             state_grad = Gradient(grad_method=method, epsilon=shots ** (-1 / 6.)).convert(
                 operator=op,
                 params=params)
@@ -656,7 +656,7 @@ class TestGradients(QiskitAquaTestCase):
 
         shots = 8000
         if method == 'fin_diff':
-            np.random.seed = 8
+            np.random.seed(8)
             prob_grad = Gradient(grad_method=method, epsilon=shots ** (-1 / 6.)).convert(
                 operator=op,
                 params=params)
@@ -702,7 +702,7 @@ class TestGradients(QiskitAquaTestCase):
         backend = BasicAer.get_backend(backend)
         q_instance = QuantumInstance(backend=backend, shots=shots)
         if method == 'fin_diff':
-            np.random.seed = 8
+            np.random.seed(8)
             prob_grad = Gradient(grad_method=method, epsilon=shots ** (-1 / 6.)).gradient_wrapper(
                 operator=op, bind_params=params, backend=q_instance)
         else:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

You cannot assign an integer to np.random.seed. It is a method.

### Details and comments


